### PR TITLE
Add HTTP proxy support

### DIFF
--- a/lib/mpns.js
+++ b/lib/mpns.js
@@ -55,6 +55,7 @@ function PushMessage(pushType, quickNotificationClass, targetName, options) {
     if (options) {
         copyOfInterest(options, this, propertiesOfInterest, this.pushType === 'tile');
         copyOfInterest(options, this, sslProperties);
+        copyOfInterest(options, this, httpProperties);
     }
 }
 
@@ -73,6 +74,15 @@ PushMessage.prototype.send = function(pushUri, callback) {
 
     if(this.targetName){
         options.headers['X-WindowsPhone-Target'] = this.targetName;
+    }
+
+    if (this.proxy) {
+        var proxyOptions = url.parse(this.proxy);
+        options.headers['Host'] = options.host;
+        options.path = options.href;
+        options.host = proxyOptions.host;
+        options.hostname = proxyOptions.hostname;
+        options.port = proxyOptions.port;
     }
 
     var result = { };
@@ -299,6 +309,7 @@ function send(type, typeProperties, objectType, args) {
         var payload = Array.prototype.shift.apply(args);
         copyOfInterest(payload, params, typeProperties, type === 'tile');
         copyOfInterest(payload, params, sslProperties, false);
+        copyOfInterest(payload, params, httpProperties, false);
     }
     else {
         // assume parameters are provided as atomic, string arguments of the function call
@@ -324,6 +335,10 @@ function send(type, typeProperties, objectType, args) {
     var instance = new objectType(params);
     instance.send(pushUri, callback);
 }
+
+var httpProperties = [
+    'proxy'
+];
 
 //tls.connect ssl params
 var sslProperties = [


### PR DESCRIPTION
Added HTTP proxy server support for the requests to MPNS

Example:
mpns.sendToast(pushUri, {proxy: 'http://yourproxy:8080', text1: 'Hello', text2: 'World'}, callback)
