### PR TITLE
Support for Sound property for toasts (GDR3+)

### DIFF
--- a/lib/mpns.js
+++ b/lib/mpns.js
@@ -268,6 +268,7 @@ function toastToXml(options) {
         wrapValue(options, 'text1', 'Text1') +
         wrapValue(options, 'text2', 'Text2') +
         wrapValue(options, 'param', 'Param') +
+        wrapValue(options, 'sound', 'Sound') +
         getPushFooter(type);
 }
 
@@ -371,7 +372,8 @@ var properties = {
     toast: [
         'text1',
         'text2',
-        'param'
+        'param',
+        'sound'
     ],
     tile: [
         'backgroundImage',


### PR DESCRIPTION
I added support for the Sound property. This can further be extended to add support for a silent notification:
<wp:Sound Silent="true" />
as per
http://msdn.microsoft.com/en-us/library/windowsphone/develop/jj662938(v=vs.105).aspx#BKMK_gdr3
but I leave that for Jeff to decide how to add properties on the xml entities in his code.
